### PR TITLE
Replace deprecated threading.currentThread with current_thread

### DIFF
--- a/goslate.py
+++ b/goslate.py
@@ -184,7 +184,7 @@ class Goslate(object):
             except socket.error as e:
                 if self._DEBUG:
                     import threading
-                    print(threading.currentThread(), e)
+                    print(threading.current_thread(), e)
                 if 'Connection reset by peer' not in str(e):
                     raise e
                 exception = e


### PR DESCRIPTION
`threading.currentThread` was deprecated in Python 3.10 (October 2021) and will be removed in Python 3.12 (October 2023).

Replace with `threading.current_thread`, added in Python 2.6 (October 2008).

* https://docs.python.org/3.12/whatsnew/3.10.html#deprecated
* https://github.com/python/cpython/pull/25174

